### PR TITLE
[CORE-API] Create npm script to run Typeorm with ts-node by default

### DIFF
--- a/core-api/ormconfig.json
+++ b/core-api/ormconfig.json
@@ -1,5 +1,4 @@
 {
-    "name": "core",
     "type": "postgres",
     "host": "core-db",
     "port": 5432,

--- a/core-api/package.json
+++ b/core-api/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "start": "ts-node ./src/app.ts",
-    "start:dev": "ts-node-dev ./src/app.ts"
+    "start:dev": "ts-node-dev ./src/app.ts",
+    "typeorm": "ts-node ./node_modules/.bin/typeorm"
   },
   "devDependencies": {
     "@types/express": "^4.16.1",

--- a/core-api/src/config/database.config.ts
+++ b/core-api/src/config/database.config.ts
@@ -4,7 +4,7 @@ import { createConnection, getRepository, Repository, ObjectType, EntitySchema }
 * @class DatabaseConfig
 */
 export default class DatabaseConfig {
-    public static connectionName: string = `core`;
+    public static connectionName: string = `default`;
 
     public static async connect() {
         for (let i = 0; i < 5; i++) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./core-api:/microhangry/core-api
+      - ./core-api:/app
     depends_on:
       - core-db


### PR DESCRIPTION
Solves #2 

### How to generate, run or revert migrations (for now on)
1. Enter in the `core-api` container:
```
docker exec -it {container_id} sh
```
2. Run Typeorm using the new npm script:
```
npm run typeorm -- migration:generate -n InitialMigration
npm run typeorm -- migration:run
npm run typeorm -- migration:revert
```
The migrations will be located at `core-api/src/database/migrations`
### Why it is needed
Typeorm generates migrations as Typescript files, but to run them you'll need to:
- Compile it to Javascript and run with node, or
- Run with ts-node

This npm script helps with the second option. 
