### PR TITLE
[ORDER-SERVICE] Create OrderItem entity and status update logic

### DIFF
--- a/order-service/src/database/migration/1561396618110-OrderItems.ts
+++ b/order-service/src/database/migration/1561396618110-OrderItems.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class OrderItems1561396618110 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`CREATE TABLE "order_item" ("id" SERIAL NOT NULL, "mealId" integer NOT NULL, "quantity" integer NOT NULL, "orderId" integer, CONSTRAINT "PK_d01158fe15b1ead5c26fd7f4e90" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "order_item" ADD CONSTRAINT "FK_646bf9ece6f45dbe41c203e06e0" FOREIGN KEY ("orderId") REFERENCES "order"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "order_item" DROP CONSTRAINT "FK_646bf9ece6f45dbe41c203e06e0"`);
+        await queryRunner.query(`DROP TABLE "order_item"`);
+    }
+
+}

--- a/order-service/src/entities/order.entity.ts
+++ b/order-service/src/entities/order.entity.ts
@@ -2,13 +2,12 @@ import {
     Column,
     Entity,
     PrimaryGeneratedColumn,
-    CreateDateColumn,
-    UpdateDateColumn,
-    ManyToOne,
+    OneToMany,
 } from "typeorm";
 import { IsIn } from "class-validator";
 import Messages from "../utils/Messages";
 import OrderStatus from "../utils/OrderStatus";
+import { OrderItem } from "./orderItem.entity";
 
 /**
  * @namespace Entities
@@ -29,16 +28,20 @@ export class Order {
     public checkoutSlotId: number;
 
     @Column()
-    @IsIn(Object.keys(OrderStatus).map((key) => { return Number(key) }), {
+    @IsIn(Object.keys(OrderStatus).map((key) => Number(key)), {
         message: Messages.validation.order_status_dont_exist,
     })
     public statusId: number;
 
-    constructor(userId: number, placeId: number, checkoutSlotId: number, statusId: number) {
+    @OneToMany(type => OrderItem, item => item.order, { eager: true, cascade: true })
+    public items: OrderItem[];
+
+    constructor(userId: number, placeId: number, checkoutSlotId: number, statusId: number, items: OrderItem[]) {
         this.userId = userId;
         this.placeId = placeId;
         this.checkoutSlotId = checkoutSlotId;
         this.statusId = statusId;
+        this.items = items;
     }
 
     public getId(): number {
@@ -81,4 +84,12 @@ export class Order {
         return this.statusId;
     }
 
+    public getItems(): OrderItem[] {
+        return this.items;
+    }
+
+    public setItems(items: OrderItem[]): OrderItem[] {
+        this.items = items;
+        return this.items;
+    }
 }

--- a/order-service/src/entities/orderItem.entity.ts
+++ b/order-service/src/entities/orderItem.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+} from "typeorm";
+import { Order } from "./order.entity";
+
+/**
+* @namespace Entities
+* @class OrderItem
+*/
+@Entity()
+export class OrderItem {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @ManyToOne(type => Order)
+  public order: Order;
+
+  @Column()
+  public mealId: number;
+
+  @Column()
+  public quantity: number;
+
+  constructor(mealId: number, quantity: number) {
+    this.mealId = mealId;
+    this.quantity = quantity;
+  }
+
+  public getId(): number {
+    return this.id;
+  }
+
+  public getOrder(): Order {
+    return this.order;
+  }
+
+  public setOrder(order: Order): Order {
+    this.order = order;
+    return this.order;
+  }
+
+  public getMealId(): number {
+    return this.mealId;
+  }
+
+  public setMealId(mealId: number): number {
+    this.mealId = mealId;
+    return this.mealId;
+  }
+
+  public getQuantity(): number {
+    return this.quantity;
+  }
+
+  public setQuantity(quantity: number): number {
+    this.quantity = quantity;
+    return this.quantity;
+  }
+}

--- a/order-service/src/routes/order.route.ts
+++ b/order-service/src/routes/order.route.ts
@@ -8,9 +8,11 @@ function OrderRouter(): Router {
     router.post("/create", OrderController.createOrder);
     router.get("/", OrderController.getAllOrders);
     router.get("/:id", OrderController.getOrderById);
+    router.put("/:id", OrderController.updateOrderStatus);
     router.get("/user/:userId", OrderController.getOrderByUserId);
     router.get("/place/:placeId", OrderController.getOrderByPlaceId);
     router.get("/status/:status", OrderController.getOrderByStatus);
+    router.get("/:id/items", OrderController.getItemsByOrderId);
     return router;
 }
 

--- a/order-service/src/utils/Messages.ts
+++ b/order-service/src/utils/Messages.ts
@@ -4,8 +4,11 @@
  */
 export default {
     validation: {
-        order_status_dont_exist: "Order status don't exist",
+        order_status_dont_exist: "Invalid order status",
         order_data_needs_to_be_provided: "userId, placeId, checkoutSlotId and statusId must be provided",
-        id_must_be_number: (id: string) => `${id} must be a number`
-    }
+        id_must_be_number: (id: string) => `${id} must be a number`,
+        items_must_be_an_array: `'meals' property must be a non-empty array of items ({ mealId: number, quantity: number })`,
+        item_data_needs_to_be_provided: `Item data should contain the following attributes: { mealId: number, quantity: number }`,
+    },
+    order_not_found: "Order not found"
 };

--- a/order-service/src/utils/OrderStatus.ts
+++ b/order-service/src/utils/OrderStatus.ts
@@ -4,6 +4,8 @@
  */
 export default {
     0: "New",
-    1: "Preparating",
-    2: "Waiting Checkout"
+    1: "Preparing",
+    2: "Waiting Checkout",
+    3: "Withdrawn",
+    4: "Canceled",
 };

--- a/order-service/tsconfig.json
+++ b/order-service/tsconfig.json
@@ -1,14 +1,19 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "declaration": true,
-      "removeComments": true,
-      "emitDecoratorMetadata": true,
-      "experimentalDecorators": true,
-      "target": "es6",
-      "sourceMap": true,
-      "outDir": "./dist",
-      "baseUrl": "./"
-    },
-    "exclude": ["node_modules"]
-  }
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [
+      "es2018"
+    ],
+    "target": "es6",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./"
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Solves #37 

### New/improved endpoints
- `GET /orders/:id/items`
- `POST /orders/create` should receive the following structure:
![image](https://user-images.githubusercontent.com/18203276/60042957-57de7100-9695-11e9-8354-33a473a1299d.png)
- `GET /orders` now returns all orders alongside their items.
- `PUT /orders/:id` updates the order status

### Notes
- Warning: *run migrations after merge!*