### PR TITLE
[CORE-API] CoreAPI and OrderService integration, usage of environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+NODE_ENV='development'
+
+# core-api
+CORE_HOST=core-api
+CORE_PORT=8080
+
+CORE_DB_HOST=core-db
+CORE_DB_PORT=5432
+
+# notification-service
+NOTIFICATION_HOST=notification-service
+NOTIFICATION_PORT=8081
+
+NOTIFICATION_DB_HOST=notification-db
+NOTIFICATION_DB_PORT=5433
+
+# preference-service
+PREFERENCE_HOST=preference-service
+PREFERENCE_PORT=8082
+
+PREFERENCE_DB_HOST=preference-db
+PREFERENCE_DB_PORT=5434
+
+# order-service
+ORDER_HOST=order-service
+ORDER_PORT=8083
+
+ORDER_DB_HOST=order-db
+ORDER_DB_PORT=5435

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pgdata-*
 */node_modules
+.env

--- a/core-api/ormconfig.js
+++ b/core-api/ormconfig.js
@@ -1,7 +1,7 @@
 module.exports = {
     "type": "postgres",
     "host": process.env.CORE_DB_HOST || "core-db",
-    "port": process.env.CORE_DB_PORT || 5432,
+    "port": 5432,
     "username": process.env.CORE_DB_USER || "postgres",
     "password": process.env.CORE_DB_PASS || "postgres",
     "database": process.env.CORE_DB_NAME || "core",

--- a/core-api/src/app.ts
+++ b/core-api/src/app.ts
@@ -16,7 +16,8 @@ import OrderRouter from "./routes/order.route";
 
 class Core {
     public app: Express.Application;
-    public PORT = process.env.CORE_PORT || process.env.CORE_PORT || 8080;
+    public HOST = process.env.HOST || 'localhost';
+    public PORT = process.env.PORT || 8080;
 
     constructor() {
         this.app = Express();
@@ -27,7 +28,7 @@ class Core {
         console.log(`Core API started.`);
 
         this.app.listen(this.PORT, () => {
-            console.log(`Server listening in http://localhost:${this.PORT}`);
+            console.log(`Server listening in http://${this.HOST}:${this.PORT}`);
         });
     }
 

--- a/core-api/src/app.ts
+++ b/core-api/src/app.ts
@@ -12,10 +12,11 @@ import AccessRouter from './routes/access.route';
 import CheckoutSlotRouter from "./routes/checkoutSlot.route";
 import PreferenceRoute from './routes/preference.route';
 import NotificationRouter from "./routes/notification.route";
+import OrderRouter from "./routes/order.route";
 
 class Core {
     public app: Express.Application;
-    public PORT = process.env.PORT || 8080;
+    public PORT = process.env.CORE_PORT || process.env.CORE_PORT || 8080;
 
     constructor() {
         this.app = Express();
@@ -49,6 +50,7 @@ class Core {
         this.app.use("/checkout-slots", CheckoutSlotRouter);
         this.app.use("/preferences", PreferenceRoute);
         this.app.use("/notifications", NotificationRouter);
+        this.app.use("/orders", OrderRouter);
     }
 }
 

--- a/core-api/src/controllers/order.controller.ts
+++ b/core-api/src/controllers/order.controller.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from 'express';
+import { OrderService } from '../services/order.service';
+
+/**
+ * @namespace Controllers
+ * @class OrderController
+ */
+export class OrderController {
+    public static async createOrder(req: Request, res: Response) {
+        const { userId, placeId, checkoutSlotId, items, statusId } = req.body;
+        const order = await OrderService.create(userId, placeId, checkoutSlotId, items, statusId);
+        return res.json(order);
+    }
+
+    public static async updateOrderStatus(req: Request, res: Response) {
+        const orderId = req.params.orderId;
+        const { statusId } = req.body;
+        const order = await OrderService.updateStatus(orderId, statusId);
+        return res.json(order);
+    }
+
+    public static async getAllOrders(req: Request, res: Response) {
+        const orders = await OrderService.findAll();
+        return res.json(orders);
+    }
+
+    public static async getOrderById(req: Request, res: Response) {
+        const orderId = req.params.orderId;
+        const order = await OrderService.findById(orderId);
+        return res.json(order);
+    }
+
+    public static async getOrderByUserId(req: Request, res: Response) {
+        const userId = req.params.userId;
+        const order = await OrderService.findByUser(userId);
+        return res.json(order);
+    }
+
+    public static async getOrderByPlaceId(req: Request, res: Response) {
+        const placeId = req.params.placeId;
+        const orders = await OrderService.findByPlace(placeId);
+        return res.json(orders);
+    }
+
+    public static async getOrderByStatusId(req: Request, res: Response) {
+        const statusId = req.params.statusId;
+        const orders = await OrderService.findByStatus(statusId);
+        return res.json(orders);
+    }
+
+    public static async getOrderItems(req: Request, res: Response) {
+        const orderId = req.params.orderId;
+        const orders = await OrderService.findOrderItems(orderId);
+        return res.json(orders);
+    }
+}

--- a/core-api/src/routes/order.route.ts
+++ b/core-api/src/routes/order.route.ts
@@ -1,18 +1,17 @@
 import { Router } from "express";
 import { OrderController } from "../controllers/order.controller";
 
-
 function OrderRouter(): Router {
     const router = Router();
 
     router.post("/create", OrderController.createOrder);
     router.get("/", OrderController.getAllOrders);
-    router.get("/:id", OrderController.getOrderById);
-    router.put("/:id", OrderController.updateOrderStatus);
+    router.get("/:orderId", OrderController.getOrderById);
+    router.put("/:orderId", OrderController.updateOrderStatus);
     router.get("/user/:userId", OrderController.getOrderByUserId);
     router.get("/place/:placeId", OrderController.getOrderByPlaceId);
-    router.get("/status/:statusId", OrderController.getOrderByStatus);
-    router.get("/:id/items", OrderController.getItemsByOrderId);
+    router.get("/status/:statusId", OrderController.getOrderByStatusId);
+    router.get("/:orderId/items", OrderController.getOrderItems);
 
     return router;
 }

--- a/core-api/src/services/notification.service.ts
+++ b/core-api/src/services/notification.service.ts
@@ -6,6 +6,16 @@ import adapter from 'axios/lib/adapters/http';
  * @class NotificationService
  */
 export class NotificationService {
+    public static baseUrl = () => {
+        let url = `http://${process.env.NOTIFICATION_HOST}`;
+        const port = process.env.NODE_ENV === 'development' ? 8081 : null;
+
+        if (port) {
+            url += `:${port}`;
+        }
+
+        return url;
+    }
 
     /**
      * Creates a new notification
@@ -14,7 +24,7 @@ export class NotificationService {
      */
     public static async create(message: string, userId: string): Promise<any> {
         try {
-            const notification = await axios.post('http://notification:8081/notifications/create', {
+            const notification = await axios.post(`${this.baseUrl()}/notifications/create`, {
                 message,
                 userId,
             }, { adapter });
@@ -29,7 +39,7 @@ export class NotificationService {
      */
     public static async findAllNotifications(): Promise<any> {
         try {
-            const notifications = await axios.get('http://notification:8081/notifications/', { adapter });
+            const notifications = await axios.get(`${this.baseUrl()}/notifications/`, { adapter });
             return notifications.data;
         } catch (e) {
             console.info(e.message);
@@ -42,7 +52,7 @@ export class NotificationService {
     */
     public static async findById(id: string): Promise<any> {
         try {
-            const notification = await axios.get(`http://notification:8081/notifications/${id}`, { adapter });
+            const notification = await axios.get(`${this.baseUrl()}/notifications/${id}`, { adapter });
             return notification.data;
         } catch (e) {
             console.info(e.message);
@@ -55,7 +65,7 @@ export class NotificationService {
     */
     public static async findByUserId(userId: string): Promise<any> {
         try {
-            const notifications = await axios.get(`http://notification:8081/notifications/users/${userId}`, { adapter });
+            const notifications = await axios.get(`${this.baseUrl()}/notifications/users/${userId}`, { adapter });
             return notifications.data;
         } catch (e) {
             console.info(e.message);
@@ -68,11 +78,10 @@ export class NotificationService {
     */
     public static async findByUserIdNotPulled(userId: string): Promise<any> {
         try {
-            const notifications = await axios.get(`http://notification:8081/notifications/unseen/users/${userId}`, { adapter });
+            const notifications = await axios.get(`${this.baseUrl()}/notifications/unseen/users/${userId}`, { adapter });
             return notifications.data;
         } catch (e) {
             console.info(e.message);
         }
     }
-
-} 
+}

--- a/core-api/src/services/order.service.ts
+++ b/core-api/src/services/order.service.ts
@@ -1,0 +1,106 @@
+import axios from 'axios';
+import adapter from 'axios/lib/adapters/http';
+
+/**
+ * @namespace Services
+ * @class OrderService
+ */
+export class OrderService {
+    public static baseUrl = () => {
+        let url = `http://${process.env.ORDER_HOST}`;
+        const port = process.env.ORDER_PORT;
+
+        if (port) {
+            url += `:${port}`;
+        }
+
+        return url;
+    }
+
+    public static async create(
+        userId: number,
+        placeId: number,
+        checkoutSlotId: number,
+        items: any,
+        statusId: number): Promise<any> {
+        try {
+            const order = await axios.post(`${this.baseUrl()}/orders/create`, {
+                userId,
+                placeId,
+                checkoutSlotId,
+                items,
+                statusId
+            }, { adapter });
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+
+    public static async findById(id: number): Promise<any> {
+        try {
+            const order = await axios.get(`${this.baseUrl()}/orders/${id}`, { adapter });
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+
+    public static async findAll(): Promise<any> {
+        try {
+            const order = await axios.get(`${this.baseUrl()}/orders`, { adapter });
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+
+    public static async findByUser(userId: number): Promise<any> {
+        try {
+            const order = await axios.get(`${this.baseUrl()}/orders/user/${userId}`, { adapter });
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+
+    public static async findByPlace(placeId: number): Promise<any> {
+        try {
+            const order = await axios.get(`${this.baseUrl()}/orders/place/${placeId}`, { adapter });
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+
+    public static async findByStatus(statusId: number): Promise<any> {
+        try {
+            const order = await axios.get(`${this.baseUrl()}/orders/status/${statusId}`, { adapter });
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+
+    public static async findOrderItems(orderId: number): Promise<any> {
+        try {
+            const order = await axios.get(`${this.baseUrl()}/orders/${orderId}/items`, { adapter });
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+
+    public static async updateStatus(orderId: number, statusId: number): Promise<any> {
+        try {
+            const order = await axios.put(
+                `${this.baseUrl()}/orders/${orderId}`,
+                { statusId },
+                { adapter }
+            );
+            return order.data;
+        } catch (e) {
+            return e.response.data;
+        }
+    }
+}

--- a/core-api/src/services/order.service.ts
+++ b/core-api/src/services/order.service.ts
@@ -8,7 +8,7 @@ import adapter from 'axios/lib/adapters/http';
 export class OrderService {
     public static baseUrl = () => {
         let url = `http://${process.env.ORDER_HOST}`;
-        const port = process.env.ORDER_PORT;
+        const port = process.env.NODE_ENV === 'development' ? 8081 : null;
 
         if (port) {
             url += `:${port}`;
@@ -33,6 +33,7 @@ export class OrderService {
             }, { adapter });
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }
@@ -42,15 +43,18 @@ export class OrderService {
             const order = await axios.get(`${this.baseUrl()}/orders/${id}`, { adapter });
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }
 
     public static async findAll(): Promise<any> {
+        console.log(this.baseUrl());
         try {
             const order = await axios.get(`${this.baseUrl()}/orders`, { adapter });
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }
@@ -60,6 +64,7 @@ export class OrderService {
             const order = await axios.get(`${this.baseUrl()}/orders/user/${userId}`, { adapter });
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }
@@ -69,6 +74,7 @@ export class OrderService {
             const order = await axios.get(`${this.baseUrl()}/orders/place/${placeId}`, { adapter });
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }
@@ -78,6 +84,7 @@ export class OrderService {
             const order = await axios.get(`${this.baseUrl()}/orders/status/${statusId}`, { adapter });
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }
@@ -87,6 +94,7 @@ export class OrderService {
             const order = await axios.get(`${this.baseUrl()}/orders/${orderId}/items`, { adapter });
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }
@@ -100,6 +108,7 @@ export class OrderService {
             );
             return order.data;
         } catch (e) {
+            console.info(e.message);
             return e.response.data;
         }
     }

--- a/core-api/src/services/preference.service.ts
+++ b/core-api/src/services/preference.service.ts
@@ -6,7 +6,16 @@ import adapter from 'axios/lib/adapters/http';
  * @class PreferenceService
  */
 export class PreferenceService {
+    public static baseUrl = () => {
+        let url = `http://${process.env.PREFERENCE_HOST}`;
+        const port = process.env.NODE_ENV === 'development' ? 8081 : null;
 
+        if (port) {
+            url += `:${port}`;
+        }
+
+        return url;
+    }
     /**
      * Creates a new preference in the database
      * @param userId
@@ -14,8 +23,9 @@ export class PreferenceService {
      * @param checkoutSlotId
      */
     public static async create(userId: string, placeCategoryId: string, checkoutSlotId: string): Promise<any> {
+        console.log(this.baseUrl());
         try {
-            const preference = await axios.post('http://preference:8081/preferences/create', {
+            const preference = await axios.post(`${this.baseUrl()}/preferences/create`, {
                 userId,
                 placeCategoryId,
                 checkoutSlotId
@@ -32,7 +42,7 @@ export class PreferenceService {
     */
     public static async findById(id: string): Promise<any> {
         try {
-            const preference = await axios.get(`http://preference:8081/preferences/${id}`, { adapter });
+            const preference = await axios.get(`${this.baseUrl()}/preferences/${id}`, { adapter });
             return preference.data;
         } catch (e) {
             console.info(e.message);
@@ -45,7 +55,7 @@ export class PreferenceService {
     */
     public static async findByUserId(userId: string): Promise<any> {
         try {
-            const preference = await axios.get(`http://preference:8081/preferences/users/${userId}`, { adapter });
+            const preference = await axios.get(`${this.baseUrl()}/preferences/users/${userId}`, { adapter });
             return preference.data;
         } catch (e) {
             console.info(e.message);
@@ -58,7 +68,7 @@ export class PreferenceService {
     */
     public static async findByPlaceCategoryId(placeCategoryId: string): Promise<any> {
         try {
-            const preference = await axios.get(`http://preference:8081/preferences/place-categories/${placeCategoryId}`, { adapter });
+            const preference = await axios.get(`${this.baseUrl()}/preferences/place-categories/${placeCategoryId}`, { adapter });
             return preference.data;
         } catch (e) {
             console.info(e.message);
@@ -70,7 +80,7 @@ export class PreferenceService {
      */
     public static async findAllPreferences(): Promise<any> {
         try {
-            const preferences = await axios.get('http://preference:8081/preferences/', { adapter });
+            const preferences = await axios.get(`${this.baseUrl()}/preferences/`, { adapter });
             return preferences.data;
         } catch (e) {
             console.info(e.message);

--- a/core-api/src/services/user.service.ts
+++ b/core-api/src/services/user.service.ts
@@ -72,6 +72,7 @@ export class UserService {
 
     public static async findAll(): Promise<SafeUser[]> {
         const repository = db.getRepository(User);
+        console.log(`http://${process.env.ORDER_HOST}:${process.env.ORDER_PORT}`);
 
         try {
             const users: User[] = await repository.find();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - ORDER_DB_HOST
       - ORDER_DB_PORT
     ports:
-      - "${PREFERENCE_PORT}:${PREFERENCE_PORT}"
+      - "${PREFERENCE_PORT}:8081"
     volumes:
       - ./preference-service:/app
       - /app/node_modules
@@ -81,7 +81,7 @@ services:
       - ORDER_DB_HOST
       - ORDER_DB_PORT
     ports:
-      - "${ORDER_PORT}:${ORDER_PORT}"
+      - "${ORDER_PORT}:8081"
     volumes:
       - ./order-service:/app
       - /app/node_modules
@@ -125,7 +125,7 @@ services:
       - ORDER_DB_HOST
       - ORDER_DB_PORT
     ports:
-      - "${NOTIFICATION_PORT}:${NOTIFICATION_PORT}"
+      - "${NOTIFICATION_PORT}:8081"
     volumes:
       - ./notification-service:/app
       - /app/node_modules
@@ -169,7 +169,7 @@ services:
       - ORDER_DB_HOST
       - ORDER_DB_PORT
     ports:
-      - "${CORE_PORT}:${CORE_PORT}"
+      - "${CORE_PORT}:8080"
     volumes:
       - ./core-api:/app
       - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3"
 services:
+  ###############################################
+  ## PREFERENCE-SERVICE
+  ###############################################
   preference-db:
     image: postgres
     container_name: preference-db
@@ -10,18 +13,40 @@ services:
     volumes:
       - ./pgdata-preference:/var/lib/postgresql/data
     ports:
-      - "5434:5432"
+      - "${PREFERENCE_DB_PORT}:5432"
+
   preference-service:
     build: ./preference-service
     command: npm run start:dev
     container_name: preference
+    environment:
+      - CORE_HOST
+      - CORE_PORT
+      - CORE_DB_HOST
+      - CORE_DB_PORT
+      - NOTIFICATION_HOST
+      - NOTIFICATION_PORT
+      - NOTIFICATION_DB_HOST
+      - NOTIFICATION_DB_PORT
+      - PREFERENCE_HOST
+      - PREFERENCE_PORT
+      - PREFERENCE_DB_HOST
+      - PREFERENCE_DB_PORT
+      - ORDER_HOST
+      - ORDER_PORT
+      - ORDER_DB_HOST
+      - ORDER_DB_PORT
     ports:
-      - "8082:8081"
+      - "${PREFERENCE_PORT}:${PREFERENCE_PORT}"
     volumes:
       - ./preference-service:/app
       - /app/node_modules
     depends_on:
       - preference-db
+
+  ###############################################
+  ## ORDER-SERVICE
+  ###############################################
   order-db:
     image: postgres
     container_name: order-db
@@ -32,18 +57,40 @@ services:
     volumes:
       - ./pgdata-order:/var/lib/postgresql/data
     ports:
-      - "5435:5432"
+      - "${ORDER_DB_PORT}:5432"
+
   order-service:
     build: ./order-service
     command: npm run start:dev
     container_name: order
+    environment:
+      - CORE_HOST
+      - CORE_PORT
+      - CORE_DB_HOST
+      - CORE_DB_PORT
+      - NOTIFICATION_HOST
+      - NOTIFICATION_PORT
+      - NOTIFICATION_DB_HOST
+      - NOTIFICATION_DB_PORT
+      - PREFERENCE_HOST
+      - PREFERENCE_PORT
+      - PREFERENCE_DB_HOST
+      - PREFERENCE_DB_PORT
+      - ORDER_HOST
+      - ORDER_PORT
+      - ORDER_DB_HOST
+      - ORDER_DB_PORT
     ports:
-      - "8083:8081"
+      - "${ORDER_PORT}:${ORDER_PORT}"
     volumes:
       - ./order-service:/app
       - /app/node_modules
     depends_on:
       - order-db
+
+  ###############################################
+  ## NOTIFICATION-SERVICE
+  ###############################################
   notification-db:
     image: postgres
     container_name: notification-db
@@ -54,18 +101,40 @@ services:
     volumes:
       - ./pgdata-notification:/var/lib/postgresql/data
     ports:
-      - "5433:5432"
+      - "${NOTIFICATION_DB_PORT}:5432"
+
   notification-service:
     build: ./notification-service
     command: npm run start:dev
     container_name: notification
+    environment:
+      - CORE_HOST
+      - CORE_PORT
+      - CORE_DB_HOST
+      - CORE_DB_PORT
+      - NOTIFICATION_HOST
+      - NOTIFICATION_PORT
+      - NOTIFICATION_DB_HOST
+      - NOTIFICATION_DB_PORT
+      - PREFERENCE_HOST
+      - PREFERENCE_PORT
+      - PREFERENCE_DB_HOST
+      - PREFERENCE_DB_PORT
+      - ORDER_HOST
+      - ORDER_PORT
+      - ORDER_DB_HOST
+      - ORDER_DB_PORT
     ports:
-      - "8081:8081"
+      - "${NOTIFICATION_PORT}:${NOTIFICATION_PORT}"
     volumes:
       - ./notification-service:/app
       - /app/node_modules
     depends_on:
       - notification-db
+
+  ###############################################
+  ## CORE-API
+  ###############################################
   core-db:
     image: postgres
     container_name: core-db
@@ -76,13 +145,31 @@ services:
     volumes:
       - ./pgdata-core:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${CORE_DB_PORT}:5432"
+
   core-api:
     build: ./core-api
     command: npm run start:dev
     container_name: core
+    environment:
+      - CORE_HOST
+      - CORE_PORT
+      - CORE_DB_HOST
+      - CORE_DB_PORT
+      - NOTIFICATION_HOST
+      - NOTIFICATION_PORT
+      - NOTIFICATION_DB_HOST
+      - NOTIFICATION_DB_PORT
+      - PREFERENCE_HOST
+      - PREFERENCE_PORT
+      - PREFERENCE_DB_HOST
+      - PREFERENCE_DB_PORT
+      - ORDER_HOST
+      - ORDER_PORT
+      - ORDER_DB_HOST
+      - ORDER_DB_PORT
     ports:
-      - "8080:8080"
+      - "${CORE_PORT}:${CORE_PORT}"
     volumes:
       - ./core-api:/app
       - /app/node_modules

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,2 @@
+export $(cat .env | sed 's/#.*//g' | xargs)
+docker-compose up

--- a/notification-service/ormconfig.js
+++ b/notification-service/ormconfig.js
@@ -1,7 +1,7 @@
 module.exports = {
     "type": "postgres",
     "host": process.env.NOTIFICATION_DB_HOST || "notification-db",
-    "port": process.env.NOTIFICATION_DB_PORT || 5432,
+    "port": 5432,
     "username": process.env.NOTIFICATION_DB_USER || "postgres",
     "password": process.env.NOTIFICATION_DB_PASS || "postgres",
     "database": process.env.NOTIFICATION_DB_NAME || "notification",

--- a/notification-service/src/app.ts
+++ b/notification-service/src/app.ts
@@ -6,7 +6,8 @@ import NotificationRouter from './routes/notification.route'
 
 class NotificationApp {
     public app: Express.Application;
-    public PORT = process.env.NOTIFICATION_PORT || process.env.PORT || 8080;
+    public HOST = process.env.HOST || 'localhost';
+    public PORT = process.env.PORT || 8081;
 
     constructor() {
         this.app = Express();
@@ -17,7 +18,7 @@ class NotificationApp {
         console.log(`Notification SERVICE started.`);
 
         this.app.listen(this.PORT, () => {
-            console.log(`Server listening in http://localhost:${this.PORT}`);
+            console.log(`Server listening in http://${this.HOST}:${this.PORT}`);
         });
     }
 

--- a/notification-service/src/app.ts
+++ b/notification-service/src/app.ts
@@ -6,7 +6,7 @@ import NotificationRouter from './routes/notification.route'
 
 class NotificationApp {
     public app: Express.Application;
-    public PORT = process.env.PORT || 8081;
+    public PORT = process.env.NOTIFICATION_PORT || process.env.PORT || 8080;
 
     constructor() {
         this.app = Express();

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY . /app
 RUN npm install -g typescript
 RUN npm install
-EXPOSE 8080
+EXPOSE 8081
 CMD ["npm", "run", "start:dev"]

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY . /app
 RUN npm install -g typescript
 RUN npm install
-EXPOSE 8081
+EXPOSE 8080
 CMD ["npm", "run", "start:dev"]

--- a/order-service/ormconfig.js
+++ b/order-service/ormconfig.js
@@ -1,7 +1,7 @@
 module.exports = {
     "type": "postgres",
     "host": process.env.ORDER_DB_HOST || "order-db",
-    "port": process.env.ORDER_DB_PORT || 5432,
+    "port": 5432,
     "username": process.env.ORDER_DB_USER || "postgres",
     "password": process.env.ORDER_DB_PASS || "postgres",
     "database": process.env.ORDER_DB_NAME || "order",

--- a/order-service/src/app.ts
+++ b/order-service/src/app.ts
@@ -6,7 +6,8 @@ import OrderRoute from './routes/order.route';
 
 class OrderApp {
     public app: Express.Application;
-    public PORT = process.env.ORDER_PORT || process.env.PORT || 8080;
+    public HOST = process.env.HOST || 'localhost';
+    public PORT = process.env.PORT || 8081;
 
     constructor() {
         this.app = Express();
@@ -17,7 +18,7 @@ class OrderApp {
         console.log(`Order SERVICE started.`);
 
         this.app.listen(this.PORT, () => {
-            console.log(`Server listening in http://localhost:${this.PORT}`);
+            console.log(`Server listening in http://${this.HOST}:${this.PORT}`);
         });
     }
 

--- a/order-service/src/app.ts
+++ b/order-service/src/app.ts
@@ -6,7 +6,7 @@ import OrderRoute from './routes/order.route';
 
 class OrderApp {
     public app: Express.Application;
-    public PORT = process.env.PORT || 8081;
+    public PORT = process.env.ORDER_PORT || process.env.PORT || 8080;
 
     constructor() {
         this.app = Express();

--- a/order-service/src/controllers/order.controller.ts
+++ b/order-service/src/controllers/order.controller.ts
@@ -125,9 +125,11 @@ export class OrderController {
                 Messages.validation.id_must_be_number("statusId"),
                 ErrorCode.NOT_ENOUGH_DATA,
             ).toJSON());
+
+            return;
         }
 
-        const permissions = await OrderService.findByPlaceId(statusId);
+        const permissions = await OrderService.findByStatus(statusId);
         res.json(permissions);
     }
 

--- a/order-service/src/services/notification.service.ts
+++ b/order-service/src/services/notification.service.ts
@@ -6,6 +6,16 @@ import adapter from 'axios/lib/adapters/http';
  * @class NotificationService
  */
 export class NotificationService {
+    public static baseUrl = () => {
+        let url = `http://${process.env.NOTIFICATION_HOST}`;
+        const port = process.env.NODE_ENV === 'development' ? 8081 : null;
+
+        if (port) {
+            url += `:${port}`;
+        }
+
+        return url;
+    }
 
     /**
      * Creates a new notification
@@ -14,10 +24,11 @@ export class NotificationService {
      */
     public static async create(message: string, userId: number): Promise<{}> {
         try {
-            const notification = await axios.post('http://notification:8081/notifications/create', {
+            const notification = await axios.post(`${this.baseUrl()}/notifications/create`, {
                 userId,
                 message,
             }, { adapter });
+            console.info(notification.data);
             return notification.data;
         } catch (e) {
             console.info(e.message);

--- a/preference-service/Dockerfile
+++ b/preference-service/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY . /app
 RUN npm install -g typescript
 RUN npm install
-EXPOSE 8080
+EXPOSE 8081
 CMD ["npm", "run", "start:dev"]

--- a/preference-service/Dockerfile
+++ b/preference-service/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY . /app
 RUN npm install -g typescript
 RUN npm install
-EXPOSE 8081
+EXPOSE 8080
 CMD ["npm", "run", "start:dev"]

--- a/preference-service/ormconfig.js
+++ b/preference-service/ormconfig.js
@@ -1,7 +1,7 @@
 module.exports = {
     "type": "postgres",
     "host": process.env.PREFERENCE_DB_HOST || "preference-db",
-    "port": process.env.PREFERENCE_DB_PORT || 5432,
+    "port": 5432,
     "username": process.env.PREFERENCE_DB_USER || "postgres",
     "password": process.env.PREFERENCE_DB_PASS || "postgres",
     "database": process.env.PREFERENCE_DB_NAME || "preference",

--- a/preference-service/src/app.ts
+++ b/preference-service/src/app.ts
@@ -6,7 +6,8 @@ import PreferenceRoute from './routes/preference.route';
 
 class PreferenceApp {
     public app: Express.Application;
-    public PORT = process.env.PREFERENCE_PORT || process.env.PORT || 8080;
+    public HOST = process.env.HOST || 'localhost';
+    public PORT = process.env.PORT || 8081;
 
     constructor() {
         this.app = Express();
@@ -17,7 +18,7 @@ class PreferenceApp {
         console.log(`Preferences SERVICE started.`);
 
         this.app.listen(this.PORT, () => {
-            console.log(`Server listening in http://localhost:${this.PORT}`);
+            console.log(`Server listening in http://${this.HOST}:${this.PORT}`);
         });
     }
 

--- a/preference-service/src/app.ts
+++ b/preference-service/src/app.ts
@@ -6,7 +6,7 @@ import PreferenceRoute from './routes/preference.route';
 
 class PreferenceApp {
     public app: Express.Application;
-    public PORT = process.env.PORT || 8081;
+    public PORT = process.env.PREFERENCE_PORT || process.env.PORT || 8080;
 
     constructor() {
         this.app = Express();


### PR DESCRIPTION
### Notes
Environment variables are now passed to docker-compose. To configure it correctly, the following is needed:
1. __Create a copy__ of the `.env.example` file and rename it to `.env` (notice that you should not commit this file. It's already in `.gitignore`). 
2. The `.env` file contains all the necessary values for the API to run flawlessly, but it's not loaded automatically. If you run `docker-compose up` right now, it will crash. Luckly I've created a script to load it before the system is up.
3. `chmod +x init.sh`
4. To start the development environment: 
```bash
$ ./init.sh # this will load all env variables and run docker-compose up
``` 
5. Again, `docker-compose up` is NOT safe anymore. Use `./init.sh`. 